### PR TITLE
Fixes and printing functions

### DIFF
--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -505,6 +505,7 @@ fn push_formula(stack: &mut NockStack, formula: Noun) {
     }
 }
 
+/** Note: axis must fit in a direct atom */
 pub fn raw_slot(noun: Noun, axis: u64) -> Noun {
     slot(noun, DirectAtom::new(axis).unwrap().as_bitslice())
 }

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -6,7 +6,7 @@ use bitvec::prelude::{BitSlice, Lsb0};
 use either::Either::*;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 
-#[derive(Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(Copy, Clone, FromPrimitive, ToPrimitive, Debug)]
 #[repr(u64)]
 enum NockWork {
     Done,
@@ -523,7 +523,7 @@ fn axis(mut noun: Noun, axis: &BitSlice<u64, Lsb0>) -> Noun {
                 noun = cell.head();
             }
         } else {
-            panic!("Axis tried to descend through atom.");
+            panic!("Axis tried to descend through atom: {:?}", noun);
         };
     }
     noun

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -99,7 +99,7 @@ pub fn interpret(stack: &mut NockStack, mut subject: Noun, formula: Noun) -> Nou
             }
             Nock0Axis => {
                 if let Ok(atom) = unsafe { (*(stack.local_noun_pointer(1))).as_atom() } {
-                    res = axis(subject, atom.as_bitslice());
+                    res = slot(subject, atom.as_bitslice());
                     stack.pop(&mut res);
                 } else {
                     panic!("Axis must be atom");
@@ -279,7 +279,7 @@ pub fn interpret(stack: &mut NockStack, mut subject: Noun, formula: Noun) -> Nou
                         *(stack.local_noun_pointer(0)) = work_to_noun(Nock9RestoreSubject);
                         *(stack.local_noun_pointer(2)) = subject;
                         subject = res;
-                        push_formula(stack, axis(subject, formula_axis.as_bitslice()));
+                        push_formula(stack, slot(subject, formula_axis.as_bitslice()));
                     } else {
                         panic!("Axis into core must be atom");
                     }
@@ -505,7 +505,11 @@ fn push_formula(stack: &mut NockStack, formula: Noun) {
     }
 }
 
-fn axis(mut noun: Noun, axis: &BitSlice<u64, Lsb0>) -> Noun {
+pub fn raw_slot(noun: Noun, axis: u64) -> Noun {
+    slot(noun, DirectAtom::new(axis).unwrap().as_bitslice())
+}
+
+pub fn slot(mut noun: Noun, axis: &BitSlice<u64, Lsb0>) -> Noun {
     let mut cursor = if let Some(x) = axis.last_one() {
         x
     } else {

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -32,6 +32,9 @@ fn main() -> io::Result<()> {
         .as_cell()
         .expect("Input must be jam of subject/formula pair");
     let result = interpret(&mut stack, input_cell.head(), input_cell.tail());
+    if let Ok(atom) = result.as_atom() {
+        println!("Result: {:?}", atom);
+    }
     let jammed_result = jam(&mut stack, result);
     let f_out = OpenOptions::new()
         .read(true)

--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -157,8 +157,8 @@ impl NockStack {
     }
 
     unsafe fn restore_prev_stack_pointer_from_local_west(&mut self, local: usize) {
-        *(self.previous_stack_pointer_pointer_east()) =
-            *(self.slot_pointer_east(local + 2) as *mut *mut u64);
+        *(self.previous_stack_pointer_pointer_west()) =
+            *(self.slot_pointer_west(local + 2) as *mut *mut u64);
     }
 
     unsafe fn restore_prev_stack_pointer_from_local(&mut self, local: usize) {

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -131,6 +131,10 @@ impl DirectAtom {
         Atom { direct: self }
     }
 
+    pub fn as_noun(self) -> Noun {
+        Noun { direct: self }
+    }
+
     pub fn data(self) -> u64 {
         self.0
     }


### PR DESCRIPTION
This includes a bugfix in the allocator, basic printing functions for nouns, and renames the axis function to slot because having the verb and noun named the same was awkward.