### PR TITLE
[ares][unifying equality] simplify, document, remove bugs and redundancies

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -656,6 +656,22 @@ pub unsafe fn unifying_equality(stack: &mut NockStack, a: *mut Noun, b: *mut Nou
      * senior noun, *never vice versa*, to avoid introducing references from more senior frames
      * into more junior frames, which would result in incorrect operation of the copier.
      */
+    // If the nouns are already word-equal we have nothing to do
+    if (*a).raw_equals(*b) {
+        return true;
+    };
+    // If the nouns have cached mugs which are disequal we have nothing to do
+    if let (Ok(a_alloc), Ok(b_alloc)) = (
+        (*a).as_allocated(),
+        (*b).as_allocated(),
+    ) {
+        if let (Some(a_mug), Some(b_mug)) = (a_alloc.get_cached_mug(), b_alloc.get_cached_mug())
+        {
+            if a_mug != b_mug {
+                return false;
+            };
+        };
+    };
     stack.push(1);
     stack.save_prev_stack_pointer_to_local(0);
     *(stack.alloc_in_previous_frame()) = (a, b);

--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -698,7 +698,7 @@ pub unsafe fn unifying_equality(stack: &mut NockStack, a: *mut Noun, b: *mut Nou
                             let x_as_ptr = x_cell.to_raw_pointer();
                             let y_as_ptr = y_cell.to_raw_pointer();
                             if x_as_ptr == y_as_ptr {
-                                // XX reclaim
+                                stack.reclaim_in_previous_frame::<(*mut Noun, *mut Noun)>();
                                 continue;
                             } else {
                                 if x_cell.head().raw_equals(y_cell.head())

--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -687,7 +687,7 @@ pub unsafe fn unifying_equality(stack: &mut NockStack, a: *mut Noun, b: *mut Nou
                         && memcmp(
                             x_indirect.data_pointer() as *const c_void,
                             y_indirect.data_pointer() as *const c_void,
-                            indirect_raw_size(x_indirect),
+                            indirect_raw_size(x_indirect) << 3,
                         ) == 0
                     {
                         let (_senior, junior) = senior_pointer_first(stack, x_as_ptr, y_as_ptr);


### PR DESCRIPTION
This simplifies the unifying equality implementation, removes some redundant tests, and adds a generous comment explaining the implementation and how it differs from vere.

- Make raw equality the outermost check
- Don't do anything explicity for direct atoms: equal direct atoms will pass the raw equality check: disequal direct atoms will fail it and should be allowed to fall through the type discrimination
- Don't check pointer equality on indirect atoms or cells as that was already done by the raw equality check.