### PR TITLE
[ares] fix atom initialization bug

### DIFF
--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -208,7 +208,7 @@ impl IndirectAtom {
         data: *const u64,
     ) -> Self {
         let (mut indirect, buffer) = Self::new_raw_mut(allocator, size);
-        ptr::copy_nonoverlapping(data, buffer.add(2), size);
+        ptr::copy_nonoverlapping(data, buffer, size);
         *(indirect.normalize())
     }
 


### PR DESCRIPTION
We already added 2 to the buffer in new_raw_mut, no need to do it again.  This fixed a bug in something I was tinkering with.