### PR TITLE
[ares] update rust compiler to 1.64

### DIFF
--- a/rust/nix/sources.json
+++ b/rust/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "release-22.05",
+        "branch": "nixos-22.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ff65cb28c43236eac4cbbd20a5781581d9cbbf6",
-        "sha256": "1vfz9xdkpwp1bbp7p7abwl64sfdsg0g10hbvxsvma1jdz2pnxl5h",
+        "rev": "1b82144edfcd0c86486d2e07c7298f85510e7fb8",
+        "sha256": "1qqh8hxynn0mzanmb2impfj4v62kkw6cbxcd6lghk9x4wagc229r",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9ff65cb28c43236eac4cbbd20a5781581d9cbbf6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1b82144edfcd0c86486d2e07c7298f85510e7fb8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This updates nixpkgs to track 22.11 which results in a rust compiler upgrade in shells started from shell.nix