### PR TITLE
[ares] fix bug in unifying equality

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -699,7 +699,7 @@ pub unsafe fn unifying_equality(stack: &mut NockStack, a: *mut Noun, b: *mut Nou
                         && memcmp(
                             x_indirect.data_pointer() as *const c_void,
                             y_indirect.data_pointer() as *const c_void,
-                            indirect_raw_size(x_indirect) << 3,
+                            x_indirect.size() << 3,
                         ) == 0
                     {
                         let (_senior, junior) = senior_pointer_first(stack, x_as_ptr, y_as_ptr);


### PR DESCRIPTION
Should only check that the data is equal, instead of running off into the following memory by two words.