### PR TITLE
[ares] fix the Last Bug in unifying equality

### DIFF
--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -792,15 +792,15 @@ unsafe fn senior_pointer_first<T>(
                 } else {
                     match polarity {
                         Polarity::East => {
-                            high_pointer = *(frame_pointer.sub(2)) as *const T;
-                            low_pointer = *(frame_pointer.sub(1)) as *const T;
+                            high_pointer = *(frame_pointer.sub(1)) as *const T;
+                            low_pointer = *(frame_pointer.sub(2)) as *const T;
                             frame_pointer = *(frame_pointer.sub(2)) as *const u64;
                             polarity = Polarity::West;
                             continue;
                         }
                         Polarity::West => {
-                            high_pointer = *frame_pointer as *const T;
-                            low_pointer = *(frame_pointer.add(1)) as *const T;
+                            high_pointer = *frame_pointer.add(1) as *const T;
+                            low_pointer = *frame_pointer as *const T;
                             frame_pointer = *(frame_pointer.add(1)) as *const u64;
                             polarity = Polarity::East;
                             continue;


### PR DESCRIPTION
The addition/subtraction is with respect to the polarity we matched on, but the high and low pointers are with respect to the polarity we're switching to.  The stack pointer is always at slot 0 (the outer slot) and the frame pointer is always at slot 1 (the inner slot).

This allows the "run a bunch of L2 events" test to pass.