### PR TITLE
Use patched ibig to do all allocations on nock stack

### DIFF
--- a/rust/ares/Cargo.lock
+++ b/rust/ares/Cargo.lock
@@ -13,6 +13,7 @@ name = "ares"
 version = "0.1.0"
 dependencies = [
  "ares_macros",
+ "assert_no_alloc",
  "bitvec",
  "criterion",
  "either",
@@ -32,6 +33,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "assert_no_alloc"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ca83137a482d61d916ceb1eba52a684f98004f18e0cafea230fe5579c178a3"
 
 [[package]]
 name = "atty"

--- a/rust/ares/Cargo.lock
+++ b/rust/ares/Cargo.lock
@@ -265,8 +265,7 @@ dependencies = [
 [[package]]
 name = "ibig"
 version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcc7f316b2c079dde77564a1360639c1a956a23fa96122732e416cb10717bb"
+source = "git+https://github.com/urbit/ibig-rs#7a675f26d3ca129045ba54f13c8e5bbde6784fd3"
 dependencies = [
  "cfg-if",
  "num-traits",

--- a/rust/ares/Cargo.lock
+++ b/rust/ares/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "ibig"
 version = "0.3.6"
-source = "git+https://github.com/urbit/ibig-rs#7a675f26d3ca129045ba54f13c8e5bbde6784fd3"
+source = "git+https://github.com/urbit/ibig-rs#4ab48b869384ceaaddb82de50808bca4e05aacd1"
 dependencies = [
  "cfg-if",
  "num-traits",

--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 criterion = "0.4"
 ibig = "0.3.6"
+assert_no_alloc = "1.1.2"
 
 [[bin]]
 name = "cue_pill"

--- a/rust/ares/Cargo.toml
+++ b/rust/ares/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[patch.crates-io]
+ibig = { git = 'https://github.com/urbit/ibig-rs' }
+
 [dependencies]
 ares_macros = { path = "../ares_macros" }
 bitvec = "1.0.0"

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -5,6 +5,7 @@ use crate::mem::NockStack;
 use crate::newt::Newt;
 use crate::noun::{Atom, Cell, DirectAtom, IndirectAtom, Noun};
 use ares_macros::tas;
+use assert_no_alloc::assert_no_alloc;
 use bitvec::prelude::{BitSlice, Lsb0};
 use either::Either::*;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
@@ -80,7 +81,7 @@ pub fn interpret(
         *(stack.local_noun_pointer(0)) = work_to_noun(Done);
     }
     push_formula(stack, formula);
-    loop {
+    assert_no_alloc(|| loop {
         match unsafe { noun_to_work(*(stack.local_noun_pointer(0))) } {
             Done => {
                 stack.pop(&mut res);
@@ -350,7 +351,7 @@ pub fn interpret(
                 stack.pop(&mut res);
             }
         };
-    }
+    });
     res
 }
 

--- a/rust/ares/src/jets/math.rs
+++ b/rust/ares/src/jets/math.rs
@@ -71,7 +71,9 @@ pub fn jet_add(stack: &mut NockStack, subject: Noun) -> Result<Noun, JetErr> {
     if let (Ok(a), Ok(b)) = (a.as_direct(), b.as_direct()) {
         Ok(Atom::new(stack, a.data() + b.data()).as_noun())
     } else {
-        let res = a.as_ubig(stack) + b.as_ubig(stack);
+        let a_big = a.as_ubig(stack);
+        let b_big = b.as_ubig(stack);
+        let res = UBig::add_stack(stack, a_big, b_big);
         Ok(Atom::from_ubig(stack, &res).as_noun())
     }
 }

--- a/rust/ares/src/lib.rs
+++ b/rust/ares/src/lib.rs
@@ -32,6 +32,10 @@ macro_rules! gdb {
     };
 }
 
+#[cfg(debug_assertions)]
+#[global_allocator]
+static A: assert_no_alloc::AllocDisabler = assert_no_alloc::AllocDisabler;
+
 pub(crate) use gdb;
 
 #[cfg(test)]

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -3,6 +3,7 @@ use ares::mem::NockStack;
 use ares::noun::IndirectAtom;
 use ares::serf::serf;
 use ares::serialization::{cue, jam};
+use assert_no_alloc::AllocDisabler;
 use memmap::Mmap;
 use memmap::MmapMut;
 use std::env;
@@ -12,6 +13,10 @@ use std::io;
 use std::mem;
 use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
+
+#[cfg(debug_assertions)]
+#[global_allocator]
+static A: AllocDisabler = AllocDisabler;
 
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("Must provide input filename");

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -3,7 +3,6 @@ use ares::mem::NockStack;
 use ares::noun::IndirectAtom;
 use ares::serf::serf;
 use ares::serialization::{cue, jam};
-use assert_no_alloc::AllocDisabler;
 use memmap::Mmap;
 use memmap::MmapMut;
 use std::env;
@@ -13,10 +12,6 @@ use std::io;
 use std::mem;
 use std::ptr::copy_nonoverlapping;
 use std::ptr::write_bytes;
-
-#[cfg(debug_assertions)]
-#[global_allocator]
-static A: AllocDisabler = AllocDisabler;
 
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("Must provide input filename");


### PR DESCRIPTION
This pairs with https://github.com/tczajka/ibig-rs/compare/main...urbit:ibig-rs:main to patch ibig-rs to use the nock stack for all allocations (for the operations we use).  The patch to ibig-rs is fairly invasive, but I don't know an easier way.

This includes the assert-no-alloc crate and ties it to the interpreter and jet tests, so that it will crash if we allocate at times when we're not supposed to.  This was useful for testing, and I think we should leave it on, since it gets compiled out of releases anyway.  If this crash is annoying you (eg because your printf allocates), just comment out the custom allocator in lib.rs.

This is not quite optimal for the number of copies from atoms to ubig and vice versa, but it's better than before.  Before, going from ubig to an atom required two copies: one to Vec, then another to an atom.  Now, we produce a Slice, so only the second copy happens.  Going from an atom to a ubig always copies once.  This is less expensive than it sounds, because frequently the left operand is modified in-place.

I don't have tests that thoroughly exercise the performance of bignum math, but the azimuth pill takes approximately the same amount of time to process.  If bignum math becomes a hot spot, it could be worth a more invasive patch to ibig-rs to operate direclty on atoms.

(This isn't based off the merge of philip/jets with eamsden/debug-immutable-hamt because one of my tests doesn't work due to a problem in MutHamt that I haven't debugged)