### PR TITLE
Address (most) lints suggested by `cargo clippy`

### DIFF
--- a/.github/workflows/ares-shared.yml
+++ b/.github/workflows/ares-shared.yml
@@ -21,7 +21,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Lint
-        run: cargo clippy -- --deny warnings
+        run: cargo clippy -- --deny warnings --allow clippy::missing_safety_doc
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ares-shared.yml
+++ b/.github/workflows/ares-shared.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
+      - name: Lint
+        run: cargo clippy -- --deny warnings
+
       - name: Build
         run: cargo build --verbose
 

--- a/rust/ares/benches/cue_pill.rs
+++ b/rust/ares/benches/cue_pill.rs
@@ -1,7 +1,6 @@
 use ares::mem::NockStack;
 use ares::noun::{DirectAtom, IndirectAtom};
 use ares::serialization::{cue, jam};
-use memmap;
 use std::env;
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -11,7 +10,7 @@ use std::time::SystemTime;
 
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("Must provide input filename");
-    let output_filename = format!("{}.out", filename.clone());
+    let output_filename = format!("{}.out", filename);
     let f = File::open(filename)?;
     let in_len = f.metadata()?.len();
     let mut stack = NockStack::new(1 << 10 << 10 << 10, 0);

--- a/rust/ares/src/hamt.rs
+++ b/rust/ares/src/hamt.rs
@@ -5,6 +5,10 @@ use either::Either::{self, *};
 use std::ptr::{copy_nonoverlapping, null};
 use std::slice;
 
+type MutStemEntry<T> = Either<*mut MutStem<T>, Leaf<T>>;
+
+type StemEntry<T> = Either<Stem<T>, Leaf<T>>;
+
 #[inline]
 fn chunk_to_bit(chunk: u32) -> u32 {
     1u32 << chunk
@@ -37,7 +41,7 @@ impl<T: Copy> MutStem<T> {
     }
 
     #[inline]
-    fn entry(&self, chunk: u32) -> Option<Either<*mut MutStem<T>, Leaf<T>>> {
+    fn entry(&self, chunk: u32) -> Option<MutStemEntry<T>> {
         if self.has_index(chunk) {
             if self.typemap & chunk_to_bit(chunk) != 0 {
                 unsafe { Some(Left(self.buffer[chunk as usize].stem)) }
@@ -201,7 +205,7 @@ impl<T: Copy> Stem<T> {
     }
 
     #[inline]
-    fn entry(self, chunk: u32) -> Option<(Either<Stem<T>, Leaf<T>>, usize)> {
+    fn entry(self, chunk: u32) -> Option<(StemEntry<T>, usize)> {
         self.index(chunk).map(|idx| {
             (
                 unsafe {

--- a/rust/ares/src/hamt.rs
+++ b/rust/ares/src/hamt.rs
@@ -428,6 +428,12 @@ impl<T: Copy> Hamt<T> {
     }
 }
 
+impl<T: Copy> Default for Hamt<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Copy + Preserve> Preserve for Hamt<T> {
     unsafe fn preserve(&mut self, stack: &mut NockStack) {
         if stack.in_frame(self.0.buffer) {

--- a/rust/ares/src/hamt.rs
+++ b/rust/ares/src/hamt.rs
@@ -69,7 +69,7 @@ impl<T: Copy> MutHamt<T> {
         unsafe {
             'lookup: loop {
                 let chunk = mug & 0x1f;
-                mug = mug >> 5;
+                mug >>= 5;
                 match (*stem).entry(chunk) {
                     None => {
                         break None;
@@ -79,8 +79,8 @@ impl<T: Copy> MutHamt<T> {
                     }
                     Some(Right(leaf)) => {
                         for pair in leaf.to_mut_slice().iter_mut() {
-                            if unifying_equality(stack, n, &mut (*pair).0) {
-                                break 'lookup Some((*pair).1);
+                            if unifying_equality(stack, n, &mut pair.0) {
+                                break 'lookup Some(pair.1);
                             }
                         }
                         break None;
@@ -97,13 +97,13 @@ impl<T: Copy> MutHamt<T> {
         unsafe {
             'insert: loop {
                 let chunk = mug & 0x1f;
-                mug = mug >> 5;
+                mug >>= 5;
                 match (*stem).entry(chunk) {
                     None => {
                         let new_leaf_buffer = stack.struct_alloc(1);
                         *new_leaf_buffer = (*n, t);
-                        (*stem).bitmap = (*stem).bitmap | chunk_to_bit(chunk);
-                        (*stem).typemap = (*stem).typemap & !chunk_to_bit(chunk);
+                        (*stem).bitmap |= chunk_to_bit(chunk);
+                        (*stem).typemap &= !chunk_to_bit(chunk);
                         (*stem).buffer[chunk as usize] = MutEntry {
                             leaf: Leaf {
                                 len: 1,
@@ -119,8 +119,8 @@ impl<T: Copy> MutHamt<T> {
                     }
                     Some(Right(leaf)) => {
                         for pair in leaf.to_mut_slice().iter_mut() {
-                            if unifying_equality(stack, n, &mut (*pair).0) {
-                                (*pair).1 = t;
+                            if unifying_equality(stack, n, &mut pair.0) {
+                                pair.1 = t;
                                 break 'insert;
                             }
                         }
@@ -142,9 +142,9 @@ impl<T: Copy> MutHamt<T> {
                             let leaf_chunk = (leaf_mug >> ((depth + 1) * 5)) & 0x1f;
                             (*new_stem).bitmap = chunk_to_bit(leaf_chunk);
                             (*new_stem).typemap = 0;
-                            (*new_stem).buffer[leaf_chunk as usize] = MutEntry { leaf: leaf };
+                            (*new_stem).buffer[leaf_chunk as usize] = MutEntry { leaf };
                             (*stem).buffer[chunk as usize] = MutEntry { stem: new_stem };
-                            (*stem).typemap = (*stem).typemap | chunk_to_bit(chunk);
+                            (*stem).typemap |= chunk_to_bit(chunk);
                             stem = new_stem;
                             depth += 1;
                             continue;
@@ -281,7 +281,7 @@ impl<T: Copy> Hamt<T> {
         let mut mug = mug_u32(stack, *n);
         'lookup: loop {
             let chunk = mug & 0x1F; // 5 bits
-            mug = mug >> 5;
+            mug >>= 5;
             match stem.entry(chunk) {
                 None => {
                     break None;
@@ -314,7 +314,7 @@ impl<T: Copy> Hamt<T> {
         unsafe {
             'insert: loop {
                 let chunk = mug & 0x1F; // 5 bits
-                mug = mug >> 5;
+                mug >>= 5;
                 match stem.entry(chunk) {
                     None => {
                         let new_leaf_buffer = stack.struct_alloc(1);
@@ -399,7 +399,7 @@ impl<T: Copy> Hamt<T> {
                             // next time around
                             assert!(leaf.len == 1);
                             let fake_buffer = stack.struct_alloc(1);
-                            *fake_buffer = Entry { leaf: leaf };
+                            *fake_buffer = Entry { leaf };
                             // get the mug chunk for the noun at *the next level* so
                             // we can build a fake stem for it
                             let fake_mug = mug_u32(stack, (*leaf.buffer).0);
@@ -430,13 +430,13 @@ impl<T: Copy> Hamt<T> {
 
 impl<T: Copy + Preserve> Preserve for Hamt<T> {
     unsafe fn preserve(&mut self, stack: &mut NockStack) {
-        if stack.in_frame((*self).0.buffer) {
-            let dest_buffer = stack.struct_alloc_in_previous_frame((*self).0.size());
-            copy_nonoverlapping((*self).0.buffer, dest_buffer, (*self).0.size());
-            (*self).0.buffer = dest_buffer;
+        if stack.in_frame(self.0.buffer) {
+            let dest_buffer = stack.struct_alloc_in_previous_frame(self.0.size());
+            copy_nonoverlapping(self.0.buffer, dest_buffer, self.0.size());
+            self.0.buffer = dest_buffer;
             let traversal_stack = stack.struct_alloc::<(Stem<T>, u32)>(6);
             let mut traversal_depth = 1;
-            *traversal_stack = ((*self).0, 0);
+            *traversal_stack = (self.0, 0);
             'preserve: loop {
                 if traversal_depth == 0 {
                     break;
@@ -487,8 +487,8 @@ impl<T: Copy + Preserve> Preserve for Hamt<T> {
                                     buffer: dest_buffer,
                                 };
                                 for pair in new_leaf.to_mut_slice().iter_mut() {
-                                    (*pair).0.preserve(stack);
-                                    (*pair).1.preserve(stack);
+                                    pair.0.preserve(stack);
+                                    pair.1.preserve(stack);
                                 }
                                 *(stem.buffer.add(idx) as *mut Entry<T>) = Entry { leaf: new_leaf };
                             }

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -653,20 +653,20 @@ fn match_pre_hint(
                         return Err(());
                     }
                 }
-                return Ok(jet_res);
+                Ok(jet_res)
             } else {
                 // Print jet errors and punt to Nock
                 eprintln!("\rJet {} failed", jet_name);
-                return Err(());
+                Err(())
             }
         }
         tas!(b"memo") => {
             let formula = unsafe { *stack.local_noun_pointer(2) };
             let mut key = Cell::new(stack, subject, formula).as_noun();
             if let Some(res) = cache.lookup(stack, &mut key) {
-                return Ok(res);
+                Ok(res)
             } else {
-                return Err(());
+                Err(())
             }
         }
         _ => Err(()),
@@ -711,10 +711,8 @@ fn match_post_hinted(
             let formula = unsafe { *stack.local_noun_pointer(2) };
             let mut key = Cell::new(stack, subject, formula).as_noun();
             *cache = cache.insert(stack, &mut key, res);
-            return Ok(());
+            Ok(())
         }
-        _ => {
-            return Err(());
-        }
+        _ => Err(()),
     }
 }

--- a/rust/ares/src/interpreter.rs
+++ b/rust/ares/src/interpreter.rs
@@ -640,7 +640,7 @@ fn match_pre_hint(
             let jet_formula = cell.tail().as_cell()?;
             let jet_name = jet_formula.tail();
 
-            let jet = jets::get_jet(jet_name)?;
+            let jet = jets::get_jet(jet_name).ok_or(())?;
             if let Ok(mut jet_res) = jet(stack, subject) {
                 // if in test mode, check that the jet returns the same result as the raw nock
                 if jets::get_jet_test_mode(jet_name) {

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -69,8 +69,11 @@ pub fn get_jet(jet_name: Noun) -> Option<Jet> {
 }
 
 pub fn get_jet_test_mode(jet_name: Noun) -> bool {
+    /*
     match jet_name.as_direct().unwrap().data() {
-        // tas!(b"cut") => true,
+        tas!(b"cut") => true,
         _ => false,
     }
+    */
+    false
 }

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -68,7 +68,7 @@ pub fn get_jet(jet_name: Noun) -> Option<Jet> {
     }
 }
 
-pub fn get_jet_test_mode(jet_name: Noun) -> bool {
+pub fn get_jet_test_mode(_jet_name: Noun) -> bool {
     /*
     match jet_name.as_direct().unwrap().data() {
         tas!(b"cut") => true,

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -2,7 +2,7 @@ pub mod math;
 
 use crate::jets::math::*;
 use crate::mem::NockStack;
-use crate::noun::Noun;
+use crate::noun::{self, Noun};
 use ares_macros::tas;
 
 crate::gdb!();
@@ -21,6 +21,12 @@ pub enum JetErr {
 impl From<()> for JetErr {
     fn from(_: ()) -> Self {
         JetErr::NonDeterministic
+    }
+}
+
+impl From<noun::Error> for JetErr {
+    fn from(_err: noun::Error) -> Self {
+        Self::NonDeterministic
     }
 }
 

--- a/rust/ares/src/jets.rs
+++ b/rust/ares/src/jets.rs
@@ -34,36 +34,36 @@ impl From<JetErr> for () {
     fn from(_: JetErr) -> Self {}
 }
 
-pub fn get_jet(jet_name: Noun) -> Result<Jet, ()> {
-    match jet_name.as_direct()?.data() {
-        tas!(b"dec") => Ok(jet_dec),
-        tas!(b"add") => Ok(jet_add),
-        tas!(b"sub") => Ok(jet_sub),
-        tas!(b"mul") => Ok(jet_mul),
-        tas!(b"div") => Ok(jet_div),
-        tas!(b"mod") => Ok(jet_mod),
-        tas!(b"dvr") => Ok(jet_dvr),
-        tas!(b"lth") => Ok(jet_lth),
-        tas!(b"lte") => Ok(jet_lte),
-        tas!(b"gth") => Ok(jet_gth),
-        tas!(b"gte") => Ok(jet_gte),
-        tas!(b"bex") => Ok(jet_bex),
-        tas!(b"lsh") => Ok(jet_lsh),
-        tas!(b"rsh") => Ok(jet_rsh),
-        tas!(b"con") => Ok(jet_con),
-        tas!(b"dis") => Ok(jet_dis),
-        tas!(b"mix") => Ok(jet_mix),
-        tas!(b"end") => Ok(jet_end),
-        tas!(b"cat") => Ok(jet_cat),
-        tas!(b"cut") => Ok(jet_cut),
-        tas!(b"can") => Ok(jet_can),
-        tas!(b"rep") => Ok(jet_rep),
-        tas!(b"rip") => Ok(jet_rip),
-        tas!(b"met") => Ok(jet_met),
-        tas!(b"mug") => Ok(jet_mug),
+pub fn get_jet(jet_name: Noun) -> Option<Jet> {
+    match jet_name.as_direct().ok()?.data() {
+        tas!(b"dec") => Some(jet_dec),
+        tas!(b"add") => Some(jet_add),
+        tas!(b"sub") => Some(jet_sub),
+        tas!(b"mul") => Some(jet_mul),
+        tas!(b"div") => Some(jet_div),
+        tas!(b"mod") => Some(jet_mod),
+        tas!(b"dvr") => Some(jet_dvr),
+        tas!(b"lth") => Some(jet_lth),
+        tas!(b"lte") => Some(jet_lte),
+        tas!(b"gth") => Some(jet_gth),
+        tas!(b"gte") => Some(jet_gte),
+        tas!(b"bex") => Some(jet_bex),
+        tas!(b"lsh") => Some(jet_lsh),
+        tas!(b"rsh") => Some(jet_rsh),
+        tas!(b"con") => Some(jet_con),
+        tas!(b"dis") => Some(jet_dis),
+        tas!(b"mix") => Some(jet_mix),
+        tas!(b"end") => Some(jet_end),
+        tas!(b"cat") => Some(jet_cat),
+        tas!(b"cut") => Some(jet_cut),
+        tas!(b"can") => Some(jet_can),
+        tas!(b"rep") => Some(jet_rep),
+        tas!(b"rip") => Some(jet_rip),
+        tas!(b"met") => Some(jet_met),
+        tas!(b"mug") => Some(jet_mug),
         _ => {
             // eprintln!("Unknown jet: {:?}", jet_name);
-            Err(())
+            None
         }
     }
 }

--- a/rust/ares/src/main.rs
+++ b/rust/ares/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> io::Result<()> {
         return serf();
     }
 
-    let output_filename = format!("{}.out", filename.clone());
+    let output_filename = format!("{}.out", filename);
     let f = File::open(filename)?;
     let in_len = f.metadata()?.len();
     let mut stack = NockStack::new(8 << 10 << 10, 0);

--- a/rust/ares/src/mem.rs
+++ b/rust/ares/src/mem.rs
@@ -98,12 +98,12 @@ impl NockStack {
             *frame_pointer.add(1) = ptr::null::<u64>() as u64;
         };
         NockStack {
-            start: start,
-            size: size,
+            start,
+            size,
             polarity: Polarity::West,
-            stack_pointer: stack_pointer,
-            frame_pointer: frame_pointer,
-            memory: memory,
+            stack_pointer,
+            frame_pointer,
+            memory,
         }
     }
 

--- a/rust/ares/src/newt.rs
+++ b/rust/ares/src/newt.rs
@@ -82,7 +82,7 @@ impl Newt {
     fn write_noun(&mut self, stack: &mut NockStack, noun: Noun) {
         let atom = jam(stack, noun);
         let size = atom.size() << 3;
-        let mut buf = vec![0 as u8; size + 5];
+        let mut buf = vec![0u8; size + 5];
         buf[1] = size as u8;
         buf[2] = (size >> 8) as u8;
         buf[3] = (size >> 16) as u8;
@@ -192,8 +192,7 @@ impl Newt {
 
     /** Fetch next message. */
     pub fn next(&mut self, stack: &mut NockStack) -> Option<Noun> {
-        let mut header: Vec<u8> = Vec::with_capacity(5);
-        header.resize(5, 0);
+        let mut header: Vec<u8> = vec![0; 5];
         if let Err(err) = self.input.read_exact(&mut header) {
             if err.kind() == std::io::ErrorKind::UnexpectedEof {
                 return None;

--- a/rust/ares/src/newt.rs
+++ b/rust/ares/src/newt.rs
@@ -218,3 +218,9 @@ impl Newt {
         Some(cue(stack, atom))
     }
 }
+
+impl Default for Newt {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -370,7 +370,7 @@ impl IndirectAtom {
             if index == 0 || *(data.add(index)) != 0 {
                 break;
             }
-            index = index - 1;
+            index -= 1;
         }
         *(self.to_raw_pointer_mut().add(1)) = (index + 1) as u64;
         self

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -63,7 +63,7 @@ fn acyclic_noun_go(noun: Noun, seen: &mut IntMap<()>) -> bool {
     match noun.as_either_atom_cell() {
         Either::Left(_atom) => true,
         Either::Right(cell) => {
-            if let Some(_) = seen.get(cell.0) {
+            if seen.get(cell.0).is_some() {
                 false
             } else {
                 seen.insert(cell.0, ());
@@ -155,8 +155,8 @@ impl DirectAtom {
         self.0
     }
 
-    pub fn as_bitslice<'a>(&'a self) -> &'a BitSlice<u64, Lsb0> {
-        &(BitSlice::from_element(&self.0))
+    pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
+        BitSlice::from_element(&self.0)
     }
 }
 
@@ -345,16 +345,16 @@ impl IndirectAtom {
         unsafe { self.to_raw_pointer().add(2) as *const u64 }
     }
 
-    pub fn as_slice<'a>(&'a self) -> &'a [u64] {
+    pub fn as_slice(&self) -> &[u64] {
         unsafe { from_raw_parts(self.data_pointer(), self.size()) }
     }
 
-    pub fn as_bytes<'a>(&'a self) -> &'a [u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         unsafe { from_raw_parts(self.data_pointer() as *const u8, self.size() << 3) }
     }
 
     /** BitSlice view on an indirect atom, with lifetime tied to reference to indirect atom. */
-    pub fn as_bitslice<'a>(&'a self) -> &'a BitSlice<u64, Lsb0> {
+    pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
         BitSlice::from_slice(self.as_slice())
     }
 
@@ -617,11 +617,11 @@ impl Atom {
         }
     }
 
-    pub fn as_bitslice<'a>(&'a self) -> &'a BitSlice<u64, Lsb0> {
+    pub fn as_bitslice(&self) -> &BitSlice<u64, Lsb0> {
         if self.is_indirect() {
             unsafe { self.indirect.as_bitslice() }
         } else {
-            unsafe { &(self.direct.as_bitslice()) }
+            unsafe { self.direct.as_bitslice() }
         }
     }
 
@@ -843,7 +843,7 @@ impl Noun {
     }
 
     pub unsafe fn from_raw(raw: u64) -> Noun {
-        Noun { raw: raw }
+        Noun { raw }
     }
 
     /** Produce the total size of a noun, in words

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -97,6 +97,30 @@ fn is_cell(noun: u64) -> bool {
     noun & CELL_MASK == CELL_TAG
 }
 
+/** A noun-related error. */
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /** Expected type [`Allocated`]. */
+    NotAllocated,
+    /** Expected type [`Atom`]. */
+    NotAtom,
+    /** Expected type [`Cell`]. */
+    NotCell,
+    /** Expected type [`DirectAtom`]. */
+    NotDirectAtom,
+    /** Expected type [`IndirectAtom`]. */
+    NotIndirectAtom,
+    /** The value can't be represented by the given type. */
+    NotRepresentable,
+}
+
+impl From<Error> for () {
+    fn from(_: Error) -> Self {}
+}
+
+/** A [`Result`] that returns an [`Error`] on error. */
+pub type Result<T> = std::result::Result<T, Error>;
+
 /** A direct atom.
  *
  * Direct atoms represent an atom up to and including DIRECT_MAX as a machine word.
@@ -117,9 +141,9 @@ impl DirectAtom {
     }
 
     /** Create a new direct atom, or return Err if the value is greater than DIRECT_MAX */
-    pub const fn new(value: u64) -> Result<Self, ()> {
+    pub const fn new(value: u64) -> Result<Self> {
         if value > DIRECT_MAX {
-            Err(())
+            Err(Error::NotRepresentable)
         } else {
             Ok(DirectAtom(value))
         }
@@ -593,19 +617,19 @@ impl Atom {
         unsafe { is_indirect_atom(self.raw) }
     }
 
-    pub fn as_direct(&self) -> Result<DirectAtom, ()> {
+    pub fn as_direct(&self) -> Result<DirectAtom> {
         if self.is_direct() {
             unsafe { Ok(self.direct) }
         } else {
-            Err(())
+            Err(Error::NotDirectAtom)
         }
     }
 
-    pub fn as_indirect(&self) -> Result<IndirectAtom, ()> {
+    pub fn as_indirect(&self) -> Result<IndirectAtom> {
         if self.is_indirect() {
             unsafe { Ok(self.indirect) }
         } else {
-            Err(())
+            Err(Error::NotIndirectAtom)
         }
     }
 
@@ -781,43 +805,43 @@ impl Noun {
         unsafe { is_cell(self.raw) }
     }
 
-    pub fn as_direct(&self) -> Result<DirectAtom, ()> {
+    pub fn as_direct(&self) -> Result<DirectAtom> {
         if self.is_direct() {
             unsafe { Ok(self.direct) }
         } else {
-            Err(())
+            Err(Error::NotDirectAtom)
         }
     }
 
-    pub fn as_indirect(&self) -> Result<IndirectAtom, ()> {
+    pub fn as_indirect(&self) -> Result<IndirectAtom> {
         if self.is_indirect() {
             unsafe { Ok(self.indirect) }
         } else {
-            Err(())
+            Err(Error::NotIndirectAtom)
         }
     }
 
-    pub fn as_cell(&self) -> Result<Cell, ()> {
+    pub fn as_cell(&self) -> Result<Cell> {
         if self.is_cell() {
             unsafe { Ok(self.cell) }
         } else {
-            Err(())
+            Err(Error::NotCell)
         }
     }
 
-    pub fn as_atom(&self) -> Result<Atom, ()> {
+    pub fn as_atom(&self) -> Result<Atom> {
         if self.is_atom() {
             unsafe { Ok(self.atom) }
         } else {
-            Err(())
+            Err(Error::NotAtom)
         }
     }
 
-    pub fn as_allocated(&self) -> Result<Allocated, ()> {
+    pub fn as_allocated(&self) -> Result<Allocated> {
         if self.is_allocated() {
             unsafe { Ok(self.allocated) }
         } else {
-            Err(())
+            Err(Error::NotAllocated)
         }
     }
 

--- a/rust/ares/src/noun.rs
+++ b/rust/ares/src/noun.rs
@@ -469,7 +469,7 @@ impl Cell {
         &mut (*self.to_raw_pointer_mut()).head as *mut Noun
     }
 
-    pub unsafe fn tail_as_mut<'a>(mut self) -> *mut Noun {
+    pub unsafe fn tail_as_mut(mut self) -> *mut Noun {
         &mut (*self.to_raw_pointer_mut()).tail as *mut Noun
     }
 

--- a/rust/ares/src/serf.rs
+++ b/rust/ares/src/serf.rs
@@ -31,8 +31,8 @@ pub fn serf() -> io::Result<()> {
     snap_path.push("chk");
     create_dir_all(&snap_path)?;
 
-    let ref mut stack = NockStack::new(96 << 10 << 10, 0);
-    let ref mut newt = Newt::new();
+    let stack = &mut NockStack::new(96 << 10 << 10, 0);
+    let newt = &mut Newt::new();
     let mut event_number;
     let mut arvo;
 
@@ -42,13 +42,7 @@ pub fn serf() -> io::Result<()> {
     newt.ripe(stack, event_number, mug as u64);
 
     // Can't use for loop because it borrows newt
-    loop {
-        let writ = if let Some(writ) = newt.next(stack) {
-            writ
-        } else {
-            break;
-        };
-
+    while let Some(writ) = newt.next(stack) {
         let tag = raw_slot(writ, 2).as_direct().unwrap();
         match tag.data() {
             tas!(b"live") => {
@@ -89,18 +83,14 @@ pub fn serf() -> io::Result<()> {
                 // event_number = raw_slot(writ, 6).as_direct().unwrap().data();
 
                 let mut lit = raw_slot(writ, 7);
-                loop {
-                    if let Ok(cell) = lit.as_cell() {
-                        if run {
-                            let ovo = cell.head();
-                            let res = slam(stack, newt, arvo, POKE_AXIS, ovo).as_cell().unwrap();
-                            arvo = res.tail();
-                        }
-                        event_number += 1;
-                        lit = cell.tail();
-                    } else {
-                        break;
+                while let Ok(cell) = lit.as_cell() {
+                    if run {
+                        let ovo = cell.head();
+                        let res = slam(stack, newt, arvo, POKE_AXIS, ovo).as_cell().unwrap();
+                        arvo = res.tail();
                     }
+                    event_number += 1;
+                    lit = cell.tail();
                 }
                 newt.play_done(stack, 0);
             }

--- a/rust/ares/src/serialization.rs
+++ b/rust/ares/src/serialization.rs
@@ -168,9 +168,9 @@ pub fn jam(stack: &mut NockStack, noun: Noun) -> Atom {
     let (atom, slice) = unsafe { IndirectAtom::new_raw_mut_bitslice(stack, size) };
     let mut state = JamState {
         cursor: 0,
-        size: size,
-        atom: atom,
-        slice: slice,
+        size,
+        atom,
+        slice,
     };
     stack.push(1);
     unsafe {

--- a/rust/ares/src/snapshot.rs
+++ b/rust/ares/src/snapshot.rs
@@ -97,7 +97,7 @@ fn latest_snapshot(
     snap_path: PathBuf,
 ) -> io::Result<(u8, u64, IndirectAtom)> {
     let res0 = load_snapshot(stack, snap_path.clone(), 0);
-    let res1 = load_snapshot(stack, snap_path.clone(), 1);
+    let res1 = load_snapshot(stack, snap_path, 1);
 
     match (res0, res1) {
         (Ok((event_number_0, state_0)), Ok((event_number_1, state_1))) => {

--- a/rust/shell.nix
+++ b/rust/shell.nix
@@ -7,6 +7,7 @@ pkgs.mkShell {
   packages = with pkgs; [
     (fenix.stable.withComponents [
       "cargo"
+      "clippy"
       "rustc"
       "rustfmt"
       "rust-src"


### PR DESCRIPTION
This PR cleans up (most of) the code flagged by Rust's linter, `cargo clippy`. A large number of `warning: unsafe function's docs miss `# Safety` section` lints remain, which we should address. Reasoning about undefined behavior in Rust is significantly harder than in C since safe Rust makes so many more assumptions than C does; unsafe Rust code, therefore, must be aware of the implications of its unsafe behavior for safe Rust code. Documenting all `unsafe` blocks with a quick justification of why the particular `unsafe` block is in fact safe and why it's necessary will make it easier to understand the code and to track down bugs related to `unsafe` blocks.